### PR TITLE
Fix script handle conflict with master theme

### DIFF
--- a/donation.php
+++ b/donation.php
@@ -182,11 +182,14 @@
 
     public function enqueue_script(){
 
+        // Use unique handle to avoid overwriting the master theme's 'main' script
+        $script_handle = 'gp-israel-donation';
+
         if ( is_page(564) ){
-            wp_enqueue_script( "main", get_stylesheet_directory_uri() ."/mainen.js", array('jquery'), filemtime(__DIR__ ."/main.js"), true );
+            wp_enqueue_script( $script_handle, get_stylesheet_directory_uri() ."/mainen.js", array('jquery'), filemtime(__DIR__ ."/main.js"), true );
         }
         else{
-            wp_enqueue_script( "main", get_stylesheet_directory_uri() ."/main.js", array('jquery'), filemtime(__DIR__ ."/main.js"), true );
+            wp_enqueue_script( $script_handle, get_stylesheet_directory_uri() ."/main.js", array('jquery'), filemtime(__DIR__ ."/main.js"), true );
         }
 
 
@@ -204,7 +207,7 @@
             'minSum' => 50, //get_post_meta($postID, "min_sum" )[0],
             'payment_type' => $recurring
         );
-        wp_localize_script( 'main', 'greenpeace_donation_object', $params );
+        wp_localize_script( $script_handle, 'greenpeace_donation_object', $params );
     }
 
     public function printUser(){


### PR DESCRIPTION
Changed wp_enqueue_script handle from 'main' to 'gp-israel-donation' to avoid overwriting the master theme's main.js bundle, which contains the carousel setup code (setupQueryLoopCarousel).